### PR TITLE
`feature` ignore lid closing during a shutdown

### DIFF
--- a/daemon/actions/bundled/handlebuttonevents.cpp
+++ b/daemon/actions/bundled/handlebuttonevents.cpp
@@ -41,6 +41,8 @@
 #include <KGlobalAccel>
 #include <TabletModeWatcher>
 
+#include <kworkspace.h>
+
 namespace PowerDevil {
 namespace BundledActions {
 HandleButtonEvents::HandleButtonEvents(QObject *parent, const QVariantList &)
@@ -135,6 +137,11 @@ void HandleButtonEvents::onButtonPressed(BackendInterface::ButtonType type)
         case BackendInterface::LidClose:
             if (!triggersLidAction()) {
                 qCWarning(POWERDEVIL) << "Lid action was suppressed because an external monitor is present";
+                return;
+            }
+
+            if (KWorkSpace::isShuttingDown()) {
+                qCWarning(POWERDEVIL) << "Lid action was suppressed because system is shutting down";
                 return;
             }
 


### PR DESCRIPTION
When pressing shut down then closing the lid before KDE shuts down, the system is put in sleep mode and the shut down is cancelled. When opening the lid again, most of KDE applets had already closed and only the wallpaper image is shown, which can be solved by switching to another TTY then using the shutdown command.

This PR should ignore lid actions when the system is shutting down. However, I'm not sure how to test it myself. I'm not familiar with CMake so idk how to build it. Also, is it possible to run it instead of the current powerdevil installed on my system or am I gonna have to use a VM to test it?

Any suggestions would be appreciated or if anyone is willing to test it.